### PR TITLE
Fix for pure computeds getting auto-evaluated after mapping

### DIFF
--- a/knockout.mapping.js
+++ b/knockout.mapping.js
@@ -277,6 +277,7 @@
             }
 
             var realDeferEvaluation = options.deferEvaluation;
+            var realIsPure = options.pure;
 
             var isRemoved = false;
 
@@ -310,7 +311,7 @@
             options.deferEvaluation = true; // will either set for just options, or both read/options.
             var realDependentObservable = realKoDependentObservable(read, owner, options);
 
-            if (!realDeferEvaluation) {
+            if (!realDeferEvaluation && !realIsPure) {
                 realDependentObservable = wrap(realDependentObservable);
                 dependentObservables.push(realDependentObservable);
             }

--- a/spec/proxyDependentObservableBehaviors.js
+++ b/spec/proxyDependentObservableBehaviors.js
@@ -42,7 +42,8 @@
                             if (createOptions.useReadCallback) {
                                 mapped.DO = createComputed({
                                     read: doData,
-                                    deferEvaluation: !!createOptions.deferEvaluation
+                                    deferEvaluation: !!createOptions.deferEvaluation,
+                                    pure: !!createOptions.pure
                                 }, mapped);
                             }
                             else if (createOptions.useWriteCallback) {
@@ -57,7 +58,8 @@
                             }
                             else {
                                 mapped.DO = createComputed(doData, mapped, {
-                                    deferEvaluation: !!createOptions.deferEvaluation
+                                    deferEvaluation: !!createOptions.deferEvaluation,
+                                    pure: !!createOptions.pure
                                 });
                             }
 
@@ -271,6 +273,17 @@
             }, 0);
         });
 
+        QUnit.test('pure dependentObservables should NOT be auto-evaluated after mapping', function(assert) {
+            var done = assert.async();
+            assert.expect(1);
+
+            var mapped = testInfo.create({pure: true});
+            window.setTimeout(function() {
+                assert.equal(testInfo.evaluationCount, 0);
+                done();
+            }, 0);
+        });
+
         QUnit.test('un-deferred dependentObservables with read callback that are NOT used immediately SHOULD be auto-evaluated after mapping', function(assert) {
             var done = assert.async();
             assert.expect(1);
@@ -299,6 +312,17 @@
             assert.expect(1);
 
             var mapped = testInfo.create({deferEvaluation: true, useReadCallback: true});
+            window.setTimeout(function() {
+                assert.equal(testInfo.evaluationCount, 0);
+                done();
+            }, 0);
+        });
+
+        QUnit.test('pure dependentObservables with read callback should NOT be auto-evaluated after mapping', function(assert) {
+            var done = assert.async();
+            assert.expect(1);
+
+            var mapped = testInfo.create({pure: true, useReadCallback: true});
             window.setTimeout(function() {
                 assert.equal(testInfo.evaluationCount, 0);
                 done();


### PR DESCRIPTION
This was a significant performance issue in an application with hundreds of cross-referencing models.

Deferred computeds were already taken care of, just adding the same check for pure computeds. Basic tests mirroring the deferred behavior included.
